### PR TITLE
Fix/backend registration

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -4,14 +4,14 @@ import type { Request, Response } from 'express';
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export async function register(req: Request, res: Response) {
-  const { role, ...userDetails } = req.body;
+  const { isTrainer, ...userDetails } = req.body;
 
-  if (!['client', 'trainer'].includes(role)) {
+  if (typeof isTrainer != 'boolean') {
     res.status(400).json({ message: 'invalid role specified!' });
     return;
   }
 
-  const makeUser = role == 'client' ? makeClient : makeTrainer;
+  const makeUser = isTrainer ? makeTrainer : makeClient;
 
   let user;
   try {
@@ -32,7 +32,7 @@ export async function register(req: Request, res: Response) {
   }
 
   const { id, name, surname } = user;
-  const accessToken = createJWT({ id, name, surname, role });
+  const accessToken = createJWT({ id, name, surname, isTrainer });
 
   res.status(201).json({ accessToken });
 }

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -42,7 +42,8 @@ export async function makeClient({
     erroneousFields.id = id;
   }
 
-  const emailRegex = /^[A-Z0-9._-]{3,64}@[A-Z0-9-]{3,64}\.[A-Z]{2,32}$/gi;
+  const emailRegex =
+    /^[A-Z0-9._-]{3,64}@[A-Z0-9-]{3,64}(\.[A-Z]{2,32}){1,2}$/gi;
   if (!email || !emailRegex.test(email)) {
     erroneousFields.email = email;
   }

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -5,7 +5,7 @@ export type SafeUserInfo = {
   id: string;
   name: string;
   surname: string;
-  role: 'client' | 'trainer';
+  isTrainer: boolean;
 };
 
 // eslint-disable-next-line jsdoc/require-jsdoc

--- a/backend/src/utils/jwt.ts
+++ b/backend/src/utils/jwt.ts
@@ -9,7 +9,7 @@ export type SafeUserInfo = {
 };
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function createJWT(userInfo: SafeUserInfo): string | Buffer {
+export function createJWT({ id, ...userInfo }: SafeUserInfo): string | Buffer {
   const jwtHeader = {
     typ: 'JWT',
     alg: 'HS256',
@@ -21,6 +21,7 @@ export function createJWT(userInfo: SafeUserInfo): string | Buffer {
 
   const issuedAt = Date.now();
   const jwtPayload = {
+    sub: id,
     iat: issuedAt,
     exp: issuedAt + 15 * 60 * 1000,
     ...userInfo,


### PR DESCRIPTION
as discussed in #19, this PR:
- [x] enhances the email regex to handle multipart TLDs (e.g .co.uk)
- [x] switches to using a boolean flag to distinguish between a client and a trainer
- [x] uses user's id as the registered claim `"sub"` to better align with the [JWT spec](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)