### PR TITLE
Fix husky's pre-commit for now

### DIFF
--- a/backend/.husky/pre-commit
+++ b/backend/.husky/pre-commit
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
-npx lint-staged --verbose --cwd $(dirname -- "$(dirname -- "$0")")
+echo "running from $(dirname -- "$0")"
+npx lint-staged --verbose

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,8 +1,3 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-# format
-npm run format
-
-# Run lint and block commit if errors
-npm run lint || (echo "❌ Lint errors found. Commit blocked."; exit 1)
+echo "running from $(dirname -- "$0")"
+npx lint-staged --verbose

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,14 @@
     "format": "prettier --write .",
     "prepare": "husky"
   },
+  "lint-staged": {
+    "**/*.{tsx, ts, jsx, js, mjs}": [
+      "eslint"
+    ],
+    "**/*.json": [
+      "prettier --write"
+    ]
+  },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
@@ -43,6 +51,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^9.1.7",
+    "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",
     "sass": "^1.89.1",
     "tailwindcss": "^4",


### PR DESCRIPTION
Under the hood, if `git.core.hooksPath` is not set, husky changes it to where it puts its git hooks when it first gets installed. in our case, it will be whatever directory that executes `npm ci` first after cloning the project. For me it was `backend/.husky/_`.

So this is not a good way since git will always run the same .husky/pre-commit, but the tweaks are enough to make it work without restructuring our project.

I also added lint-staged while we're at it.